### PR TITLE
Move SSL and BIO accessors to where they can actually access SSL and BIO

### DIFF
--- a/src/neo/io/openssl/engine.hpp
+++ b/src/neo/io/openssl/engine.hpp
@@ -99,6 +99,11 @@ public:
 
     bool needs_input() const noexcept;
 
+    void*       ssl_c_ptr() noexcept { return _ssl_ptr; }
+    const void* ssl_c_ptr() const noexcept { return _ssl_ptr; }
+    void*       bio_c_ptr() noexcept { return _bio_ptr; }
+    const void* bio_c_ptr() const noexcept { return _bio_ptr; }
+
 private:
     void* _ssl_ptr = nullptr;
     void* _bio_ptr = nullptr;
@@ -198,11 +203,6 @@ public:
 
     NEO_DECL_REF_REBINDER(rebind_input, Input, _input);
     NEO_DECL_REF_REBINDER(rebind_output, Output, _output);
-
-    void*       ssl_c_ptr() noexcept { return _ssl_ptr; }
-    const void* ssl_c_ptr() const noexcept { return _ssl_ptr; }
-    void*       bio_c_ptr() noexcept { return _bio_ptr; }
-    const void* bio_c_ptr() const noexcept { return _bio_ptr; }
 };
 
 template <buffer_source Input, buffer_sink Output>


### PR DESCRIPTION
Attempting to access `neo::ssl::engine::ssl_c_ptr()` or `neo::ssl::engine::bio_c_ptr()` in client code currently leads to a compiler error:

```
src/neo/io/openssl/engine.hpp:202:47: error: ‘void* neo::ssl::engine_base::_ssl_ptr’ is private within this context
  202 |     void*       ssl_c_ptr() noexcept { return _ssl_ptr; }
      |                                               ^~~~~~~~
src/neo/io/openssl/engine.hpp:103:11: note: declared private here
  103 |     void* _ssl_ptr = nullptr;
      |           ^~~~~~~~
```

Looking at the code, the reason for this becomes obvious: `_ssl_ptr` and `_bio_ptr` [are private](https://github.com/vector-of-bool/neo-io/blob/d2a6a6e051549ab08d1fe3edbbb4468f545e0a1f/src/neo/io/openssl/engine.hpp#L103) to `neo::ssl::engine_base`. This PR fixes the issue by simply moving the accessor methods to the base class.

---

FYI: This issue prevents me from adding TLS SNI support to bpt. :)